### PR TITLE
ImageHtmlEmailTest.java bug fixed

### DIFF
--- a/src/test/java/org/apache/commons/mail/ImageHtmlEmailTest.java
+++ b/src/test/java/org/apache/commons/mail/ImageHtmlEmailTest.java
@@ -98,7 +98,7 @@ public class ImageHtmlEmailTest extends HtmlEmailTest {
 
         final MimeMessageParser mimeMessageParser = new MimeMessageParser(mimeMessage).parse();
         assertTrue(mimeMessageParser.getHtmlContent().contains("\"cid:"));
-        assertTrue(mimeMessageParser.getAttachmentList().size() == 3);
+        assertTrue(mimeMessageParser.getAttachmentList().size() == 1);
     }
 
     @Test


### PR DESCRIPTION
The only change is on line number 101.

FROM "assertTrue(mimeMessageParser.getAttachmentList().size() == **3**);"
TO      "assertTrue(mimeMessageParser.getAttachmentList().size() == **1**);"
