### PR TITLE
Do not automatically encode attachment's filename

### DIFF
--- a/src/main/java/org/apache/commons/mail/MultiPartEmail.java
+++ b/src/main/java/org/apache/commons/mail/MultiPartEmail.java
@@ -464,16 +464,11 @@ public class MultiPartEmail extends Email
         try
         {
             bodyPart.setDisposition(disposition);
-            bodyPart.setFileName(MimeUtility.encodeText(name));
+            bodyPart.setFileName(name);
             bodyPart.setDescription(description);
             bodyPart.setDataHandler(new DataHandler(ds));
 
             getContainer().addBodyPart(bodyPart);
-        }
-        catch (final UnsupportedEncodingException uee)
-        {
-            // in case the filename could not be encoded
-            throw new EmailException(uee);
         }
         catch (final MessagingException me)
         {


### PR DESCRIPTION
As of javax.mail 1.5.6, `javax.mail.internet.MimeBodyPart` contains the method 
`static void setFileName(MimePart part, String name) `
that allows user to choose to encode the filename by `MimeUtility.encodeText(name)`. Automatically encoding of filename should not be done in commons-email, but in javax.mail.

See issue [EMAIL-138](https://issues.apache.org/jira/browse/EMAIL-138)