### PR TITLE
javax.mail:1.6.1 -> jakarta.mail:1.6.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -236,8 +236,8 @@
     <dependencies>
         <dependency>
             <groupId>com.sun.mail</groupId>
-            <artifactId>javax.mail</artifactId>
-            <version>1.6.1</version>
+            <artifactId>jakarta.mail</artifactId>
+            <version>1.6.4</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>


### PR DESCRIPTION
https://eclipse-ee4j.github.io/mail/

September 14, 2018 - JavaMail project moved to the Eclipse Foundation!