### PR TITLE
EMAIL-204: Disable eager attachment loading on MimeMessageParser

### DIFF
--- a/src/main/java/org/apache/commons/mail/util/MimeMessageParser.java
+++ b/src/main/java/org/apache/commons/mail/util/MimeMessageParser.java
@@ -270,12 +270,7 @@ public class MimeMessageParser
         final DataHandler dataHandler = part.getDataHandler();
         final DataSource dataSource = dataHandler.getDataSource();
         final String contentType = getBaseMimeType(dataSource.getContentType());
-        byte[] content;
-        try (InputStream inputStream = dataSource.getInputStream()) 
-        {
-            content = this.getContent(inputStream);
-        }
-        final ByteArrayDataSource result = new ByteArrayDataSource(content, contentType);
+        final ByteArrayDataSource result = new ByteArrayDataSource(dataSource.getInputStream(), contentType);
         final String dataSourceName = getDataSourceName(part, dataSource);
         result.setName(dataSourceName);
         return result;


### PR DESCRIPTION
As discussed on the Jira ticket, this is the MR to update MimeMessageParser.createDataSource() to construct the `ByteArrayDataSource` object with input steam instead of actual content in order to handle the situation that email with multiple and bulk attachments.