### PR TITLE
[EMAIL-206] Use SharedByteArrayInputStream for memory usage

### DIFF
--- a/src/main/java/org/apache/commons/mail/util/MimeMessageUtils.java
+++ b/src/main/java/org/apache/commons/mail/util/MimeMessageUtils.java
@@ -25,6 +25,7 @@ import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import javax.mail.util.SharedByteArrayInputStream;
 import java.nio.charset.Charset;
 
 /**
@@ -53,7 +54,7 @@ public final class MimeMessageUtils
     public static MimeMessage createMimeMessage(final Session session, final byte[] source)
         throws MessagingException, IOException
     {
-        try (ByteArrayInputStream is = new ByteArrayInputStream(source))
+        try (ByteArrayInputStream is = new SharedByteArrayInputStream(source))
         {
             return new MimeMessage(session, is);
         }
@@ -108,7 +109,7 @@ public final class MimeMessageUtils
         try
         {
             final byte[] byteSource = source.getBytes(Charset.defaultCharset());
-            is = new ByteArrayInputStream(byteSource);
+            is = new SharedByteArrayInputStream(byteSource);
             return createMimeMessage(session, is);
         }
         finally


### PR DESCRIPTION
## SharedInputStream

`Java Mail API` provides a mechanism to save memory usage.

![img_4](https://github.com/apache/commons-email/assets/63458653/3cd8c890-156f-4fbe-acee-d7047852d004)

If you use `SharedByteInputStream`, you can use it as a **Call by Reference** without assigning a new byte[] of the factor.

### Before

Memory snapshot for the test below.

```java
@Test
void memoryTest() throws Exception {
    FileInputStream fileInputStream = new FileInputStream("/test/oom.eml");
    byte[] bytes = fileInputStream.readAllBytes();
    Session session = Session.getInstance(System.getProperties());
    MimeMessage mimeMessage = new MimeMessage(session, new ByteArrayInputStream(bytes));
}
```

![img_1](https://github.com/apache/commons-email/assets/63458653/bb9b2cdc-e8a1-4ce1-97ff-7e42871d40a5)

### After

Memory snapshot for the test below.

```java
@Test
void memoryTest() throws Exception {
    FileInputStream fileInputStream = new FileInputStream("/test/oom.eml");
    byte[] bytes = fileInputStream.readAllBytes();
    Session session = Session.getInstance(System.getProperties());
    MimeMessage mimeMessage = new MimeMessage(session, new SharedByteArrayInputStream(bytes));
}
```

![img_3](https://github.com/apache/commons-email/assets/63458653/538df9e5-a0b9-4a14-a6b2-029e36e14518)

Thanks.