### PR TITLE
Better use of JUnit APIs

### DIFF
--- a/src/test/java/org/apache/commons/mail/EmailTest.java
+++ b/src/test/java/org/apache/commons/mail/EmailTest.java
@@ -928,7 +928,7 @@ public class EmailTest extends AbstractEmailTest
         final String headerValue = "1234567890 1234567890 123456789 01234567890 123456789 0123456789 01234567890 01234567890";
         email.addHeader("X-LongHeader", headerValue);
 
-		assertEquals(1, email.getHeaders().size());
+        assertEquals(1, email.getHeaders().size());
         // the header should not yet be folded -> will be done by buildMimeMessage()
         assertFalse(email.getHeaders().get("X-LongHeader").contains("\r\n"));
 

--- a/src/test/java/org/apache/commons/mail/EmailTest.java
+++ b/src/test/java/org/apache/commons/mail/EmailTest.java
@@ -928,7 +928,7 @@ public class EmailTest extends AbstractEmailTest
         final String headerValue = "1234567890 1234567890 123456789 01234567890 123456789 0123456789 01234567890 01234567890";
         email.addHeader("X-LongHeader", headerValue);
 
-        assertTrue(email.getHeaders().size() == 1);
+		assertEquals(1, email.getHeaders().size());
         // the header should not yet be folded -> will be done by buildMimeMessage()
         assertFalse(email.getHeaders().get("X-LongHeader").contains("\r\n"));
 

--- a/src/test/java/org/apache/commons/mail/ImageHtmlEmailTest.java
+++ b/src/test/java/org/apache/commons/mail/ImageHtmlEmailTest.java
@@ -98,7 +98,7 @@ public class ImageHtmlEmailTest extends HtmlEmailTest {
 
         final MimeMessageParser mimeMessageParser = new MimeMessageParser(mimeMessage).parse();
         assertTrue(mimeMessageParser.getHtmlContent().contains("\"cid:"));
-        assertTrue(mimeMessageParser.getAttachmentList().size() == 3);
+		assertEquals(3, mimeMessageParser.getAttachmentList().size());
     }
 
     @Test
@@ -239,7 +239,7 @@ public class ImageHtmlEmailTest extends HtmlEmailTest {
 
         final MimeMessageParser mimeMessageParser = new MimeMessageParser(mimeMessage).parse();
         assertTrue(mimeMessageParser.getHtmlContent().contains("\"cid:"));
-        assertTrue(mimeMessageParser.getAttachmentList().size() == 1);
+		assertEquals(1, mimeMessageParser.getAttachmentList().size());
     }
 
     @Test
@@ -279,7 +279,7 @@ public class ImageHtmlEmailTest extends HtmlEmailTest {
 
         final MimeMessageParser mimeMessageParser = new MimeMessageParser(mimeMessage).parse();
         assertTrue(mimeMessageParser.getHtmlContent().contains("\"cid:"));
-        assertTrue(mimeMessageParser.getAttachmentList().size() == 1);
+		assertEquals(1, mimeMessageParser.getAttachmentList().size());
     }
 
     @Test
@@ -322,7 +322,7 @@ public class ImageHtmlEmailTest extends HtmlEmailTest {
 
         final MimeMessageParser mimeMessageParser = new MimeMessageParser(mimeMessage).parse();
         assertTrue(mimeMessageParser.getHtmlContent().contains("\"cid:"));
-        assertTrue(mimeMessageParser.getAttachmentList().size() == 1);
+		assertEquals(1, mimeMessageParser.getAttachmentList().size());
     }
 
     @Test
@@ -365,7 +365,7 @@ public class ImageHtmlEmailTest extends HtmlEmailTest {
 
         final MimeMessageParser mimeMessageParser = new MimeMessageParser(mimeMessage).parse();
         assertTrue(mimeMessageParser.getHtmlContent().contains("\"cid:"));
-        assertTrue(mimeMessageParser.getAttachmentList().size() == 3);
+		assertEquals(3, mimeMessageParser.getAttachmentList().size());
     }
 
     @Test

--- a/src/test/java/org/apache/commons/mail/ImageHtmlEmailTest.java
+++ b/src/test/java/org/apache/commons/mail/ImageHtmlEmailTest.java
@@ -98,7 +98,7 @@ public class ImageHtmlEmailTest extends HtmlEmailTest {
 
         final MimeMessageParser mimeMessageParser = new MimeMessageParser(mimeMessage).parse();
         assertTrue(mimeMessageParser.getHtmlContent().contains("\"cid:"));
-		assertEquals(3, mimeMessageParser.getAttachmentList().size());
+        assertEquals(3, mimeMessageParser.getAttachmentList().size());
     }
 
     @Test
@@ -239,7 +239,7 @@ public class ImageHtmlEmailTest extends HtmlEmailTest {
 
         final MimeMessageParser mimeMessageParser = new MimeMessageParser(mimeMessage).parse();
         assertTrue(mimeMessageParser.getHtmlContent().contains("\"cid:"));
-		assertEquals(1, mimeMessageParser.getAttachmentList().size());
+        assertEquals(1, mimeMessageParser.getAttachmentList().size());
     }
 
     @Test
@@ -279,7 +279,7 @@ public class ImageHtmlEmailTest extends HtmlEmailTest {
 
         final MimeMessageParser mimeMessageParser = new MimeMessageParser(mimeMessage).parse();
         assertTrue(mimeMessageParser.getHtmlContent().contains("\"cid:"));
-		assertEquals(1, mimeMessageParser.getAttachmentList().size());
+        assertEquals(1, mimeMessageParser.getAttachmentList().size());
     }
 
     @Test
@@ -322,7 +322,7 @@ public class ImageHtmlEmailTest extends HtmlEmailTest {
 
         final MimeMessageParser mimeMessageParser = new MimeMessageParser(mimeMessage).parse();
         assertTrue(mimeMessageParser.getHtmlContent().contains("\"cid:"));
-		assertEquals(1, mimeMessageParser.getAttachmentList().size());
+        assertEquals(1, mimeMessageParser.getAttachmentList().size());
     }
 
     @Test
@@ -365,7 +365,7 @@ public class ImageHtmlEmailTest extends HtmlEmailTest {
 
         final MimeMessageParser mimeMessageParser = new MimeMessageParser(mimeMessage).parse();
         assertTrue(mimeMessageParser.getHtmlContent().contains("\"cid:"));
-		assertEquals(3, mimeMessageParser.getAttachmentList().size());
+        assertEquals(3, mimeMessageParser.getAttachmentList().size());
     }
 
     @Test

--- a/src/test/java/org/apache/commons/mail/util/MimeMessageParserTest.java
+++ b/src/test/java/org/apache/commons/mail/util/MimeMessageParserTest.java
@@ -54,7 +54,7 @@ public class MimeMessageParserTest
         assertTrue(mimeMessageParser.hasPlainContent());
         assertNotNull(mimeMessageParser.getPlainContent());
         assertNull(mimeMessageParser.getHtmlContent());
-        assertTrue(mimeMessageParser.getTo().size() == 1);
+        assertEquals(1, mimeMessageParser.getTo().size());
         assertTrue(mimeMessageParser.getCc().isEmpty());
         assertTrue(mimeMessageParser.getBcc().isEmpty());
         assertEquals("test_from@apache.org", mimeMessageParser.getFrom());
@@ -78,7 +78,7 @@ public class MimeMessageParserTest
         assertTrue(mimeMessageParser.hasPlainContent());
         assertNotNull(mimeMessageParser.getPlainContent());
         assertNull(mimeMessageParser.getHtmlContent());
-        assertTrue(mimeMessageParser.getTo().size() == 1);
+        assertEquals(1, mimeMessageParser.getTo().size());
         assertTrue(mimeMessageParser.getCc().isEmpty());
         assertTrue(mimeMessageParser.getBcc().isEmpty());
         assertEquals("coheigea@apache.org", mimeMessageParser.getFrom());
@@ -103,14 +103,14 @@ public class MimeMessageParserTest
         assertTrue(mimeMessageParser.hasPlainContent());
         assertNotNull(mimeMessageParser.getPlainContent());
         assertNotNull(mimeMessageParser.getHtmlContent());
-        assertTrue(mimeMessageParser.getTo().size() == 1);
+        assertEquals(1, mimeMessageParser.getTo().size());
         assertTrue(mimeMessageParser.getCc().isEmpty());
         assertTrue(mimeMessageParser.getBcc().isEmpty());
         assertEquals("siegfried.goeschl@it20one.at", mimeMessageParser.getFrom());
         assertEquals("siegfried.goeschl@it20one.at", mimeMessageParser.getReplyTo());
         assertTrue(mimeMessageParser.hasAttachments());
         final List<?> attachmentList = mimeMessageParser.getAttachmentList();
-        assertTrue(attachmentList.size() == 2);
+        assertEquals(2, attachmentList.size());
 
         dataSource = mimeMessageParser.findAttachmentByName("Wasserlilien.jpg");
         assertNotNull(dataSource);
@@ -138,14 +138,14 @@ public class MimeMessageParserTest
         assertTrue(mimeMessageParser.hasPlainContent());
         assertNotNull(mimeMessageParser.getPlainContent());
         assertNotNull(mimeMessageParser.getHtmlContent());
-        assertTrue(mimeMessageParser.getTo().size() == 1);
+        assertEquals(1, mimeMessageParser.getTo().size());
         assertTrue(mimeMessageParser.getCc().isEmpty());
         assertTrue(mimeMessageParser.getBcc().isEmpty());
         assertEquals("test_from@apache.org", mimeMessageParser.getFrom());
         assertEquals("test_from@apache.org", mimeMessageParser.getReplyTo());
         assertTrue(mimeMessageParser.hasAttachments());
         final List<?> attachmentList = mimeMessageParser.getAttachmentList();
-        assertTrue(attachmentList.size() == 1);
+        assertEquals(1, attachmentList.size());
 
         dataSource = mimeMessageParser.getAttachmentList().get(0);
         assertNotNull(dataSource);
@@ -176,14 +176,14 @@ public class MimeMessageParserTest
         assertFalse(mimeMessageParser.hasPlainContent());
         assertNull(mimeMessageParser.getPlainContent());
         assertNotNull(mimeMessageParser.getHtmlContent());
-        assertTrue(mimeMessageParser.getTo().size() == 1);
+        assertEquals(1, mimeMessageParser.getTo().size());
         assertTrue(mimeMessageParser.getCc().isEmpty());
         assertTrue(mimeMessageParser.getBcc().isEmpty());
         assertEquals("siegfried.goeschl@it20one.at", mimeMessageParser.getFrom());
         assertEquals("siegfried.goeschl@it20one.at", mimeMessageParser.getReplyTo());
         assertTrue(mimeMessageParser.hasAttachments());
         final List<?> attachmentList = mimeMessageParser.getAttachmentList();
-        assertTrue(attachmentList.size() == 1);
+        assertEquals(1, attachmentList.size());
 
         dataSource = (DataSource) attachmentList.get(0);
         assertNotNull(dataSource);
@@ -214,14 +214,14 @@ public class MimeMessageParserTest
         assertFalse(mimeMessageParser.hasPlainContent());
         assertNull(mimeMessageParser.getPlainContent());
         assertNull(mimeMessageParser.getHtmlContent());
-        assertTrue(mimeMessageParser.getTo().size() == 1);
+        assertEquals(1, mimeMessageParser.getTo().size());
         assertTrue(mimeMessageParser.getCc().isEmpty());
         assertTrue(mimeMessageParser.getBcc().isEmpty());
         assertEquals("siegfried.goeschl@it20one.at", mimeMessageParser.getFrom());
         assertEquals("siegfried.goeschl@it20one.at", mimeMessageParser.getReplyTo());
         assertTrue(mimeMessageParser.hasAttachments());
         final List<?> attachmentList = mimeMessageParser.getAttachmentList();
-        assertTrue(attachmentList.size() == 1);
+        assertEquals(1, attachmentList.size());
 
         dataSource = mimeMessageParser.findAttachmentByName("Kunde 100029   Auftrag   3600.pdf");
         assertNotNull(dataSource);
@@ -278,14 +278,14 @@ public class MimeMessageParserTest
         assertTrue(mimeMessageParser.hasPlainContent());
         assertNotNull(mimeMessageParser.getPlainContent());
         assertNull(mimeMessageParser.getHtmlContent());
-        assertTrue(mimeMessageParser.getTo().size() == 1);
+        assertEquals(1, mimeMessageParser.getTo().size());
         assertTrue(mimeMessageParser.getCc().isEmpty());
         assertTrue(mimeMessageParser.getBcc().isEmpty());
         assertEquals("test_from@apache.org", mimeMessageParser.getFrom());
         assertEquals("test_from@apache.org", mimeMessageParser.getReplyTo());
         assertTrue(mimeMessageParser.hasAttachments());
         final List<?> attachmentList = mimeMessageParser.getAttachmentList();
-        assertTrue(attachmentList.size() == 1);
+        assertEquals(1, attachmentList.size());
 
         dataSource = mimeMessageParser.findAttachmentByName("test.txt");
         assertNotNull(dataSource);
@@ -314,14 +314,14 @@ public class MimeMessageParserTest
         assertFalse(mimeMessageParser.hasPlainContent());
         assertNull(mimeMessageParser.getPlainContent());
         assertNull(mimeMessageParser.getHtmlContent());
-        assertTrue(mimeMessageParser.getTo().size() == 1);
+        assertEquals(1, mimeMessageParser.getTo().size());
         assertTrue(mimeMessageParser.getCc().isEmpty());
         assertTrue(mimeMessageParser.getBcc().isEmpty());
         assertEquals("test_from@apache.org", mimeMessageParser.getFrom());
         assertEquals("test_from@apache.org", mimeMessageParser.getReplyTo());
         assertTrue(mimeMessageParser.hasAttachments());
         final List<?> attachmentList = mimeMessageParser.getAttachmentList();
-        assertTrue(attachmentList.size() == 1);
+        assertEquals(1, attachmentList.size());
 
         dataSource = mimeMessageParser.findAttachmentByName("test.txt");
         assertNotNull(dataSource);
@@ -350,14 +350,14 @@ public class MimeMessageParserTest
         assertTrue(mimeMessageParser.hasPlainContent());
         assertNotNull(mimeMessageParser.getPlainContent());
         assertNull(mimeMessageParser.getHtmlContent());
-        assertTrue(mimeMessageParser.getTo().size() == 1);
+        assertEquals(1, mimeMessageParser.getTo().size());
         assertTrue(mimeMessageParser.getCc().isEmpty());
         assertTrue(mimeMessageParser.getBcc().isEmpty());
         assertEquals("test_from@apache.org", mimeMessageParser.getFrom());
         assertEquals("test_from@apache.org", mimeMessageParser.getReplyTo());
         assertTrue(mimeMessageParser.hasAttachments());
         final List<?> attachmentList = mimeMessageParser.getAttachmentList();
-        assertTrue(attachmentList.size() == 1);
+        assertEquals(1, attachmentList.size());
 
         dataSource = mimeMessageParser.findAttachmentByName("test.html");
         assertNotNull(dataSource);
@@ -390,7 +390,7 @@ public class MimeMessageParserTest
         assertFalse(mimeMessageParser.hasPlainContent());
         assertNull(mimeMessageParser.getPlainContent());
         assertNull(mimeMessageParser.getHtmlContent());
-        assertTrue(mimeMessageParser.getTo().size() == 1);
+        assertEquals(1, mimeMessageParser.getTo().size());
         assertTrue(mimeMessageParser.getCc().isEmpty());
         assertTrue(mimeMessageParser.getBcc().isEmpty());
         assertEquals("test_from@apache.org", mimeMessageParser.getFrom());
@@ -425,7 +425,7 @@ public class MimeMessageParserTest
         assertTrue(mimeMessageParser.hasPlainContent());
         assertNotNull(mimeMessageParser.getPlainContent());
         assertNull(mimeMessageParser.getHtmlContent());
-        assertTrue(mimeMessageParser.getTo().size() == 1);
+        assertEquals(1, mimeMessageParser.getTo().size());
         assertTrue(mimeMessageParser.getCc().isEmpty());
         assertTrue(mimeMessageParser.getBcc().isEmpty());
         assertEquals("test_from@apache.org", mimeMessageParser.getFrom());
@@ -461,7 +461,7 @@ public class MimeMessageParserTest
         assertTrue(mimeMessageParser.hasPlainContent());
         assertNotNull(mimeMessageParser.getPlainContent());
         assertNotNull(mimeMessageParser.getHtmlContent());
-        assertTrue(mimeMessageParser.getTo().size() == 1);
+        assertEquals(1, mimeMessageParser.getTo().size());
         assertTrue(mimeMessageParser.getCc().isEmpty());
         assertTrue(mimeMessageParser.getBcc().isEmpty());
         assertEquals("test_from@apache.org", mimeMessageParser.getFrom());
@@ -483,7 +483,7 @@ public class MimeMessageParserTest
         assertTrue(mimeMessageParser.isMultipart());
         assertTrue(mimeMessageParser.hasHtmlContent());
         assertNotNull(mimeMessageParser.getHtmlContent());
-        assertTrue(mimeMessageParser.getTo().size() == 1);
+        assertEquals(1, mimeMessageParser.getTo().size());
         assertTrue(mimeMessageParser.getCc().isEmpty());
         assertTrue(mimeMessageParser.getBcc().isEmpty());
         assertEquals("siegfried.goeschl@it20one.at", mimeMessageParser.getFrom());


### PR DESCRIPTION
The current test uses a mix of `assertTrue()` and `assertEquals()` for size assertion.

Change this to consistently use only **`assertEquals()`**.