### PR TITLE
[EMAIL-207] Modify createDataSource method to use AttachmentDataSource

### DIFF
--- a/src/main/java/org/apache/commons/mail/util/AttachmentDataSource.java
+++ b/src/main/java/org/apache/commons/mail/util/AttachmentDataSource.java
@@ -32,21 +32,48 @@ public class AttachmentDataSource implements DataSource {
     private final String type;
     private String name = "";
 
+    /**
+     * Create a AttachmentDataSource with data from the
+     * specified InputStream and with the specified MIME type.
+     *
+     * @param is   the InputStream
+     * @param type the MIME type
+     */
     public AttachmentDataSource(InputStream is, String type) {
         this.is = is;
         this.type = type;
     }
 
+    /**
+     * Create a AttachmentDataSource with data from the
+     * specified InputStream and with the specified MIME type
+     * and name for this DataSource.
+     *
+     * @param is
+     * @param type
+     * @param name
+     */
     public AttachmentDataSource(InputStream is, String type, String name) {
         this.is = is;
         this.type = type;
         this.name = name;
     }
 
+    /**
+     * Return an InputStream.
+     * @return the InputStream
+     */
     public InputStream getInputStream() {
         return is;
     }
 
+    /**
+     * Return an OutputStream for the data.
+     * Writing the data is not supported; an <code>IOException</code>
+     * is always thrown.
+     *
+     * @throws IOException
+     */
     public OutputStream getOutputStream() throws IOException {
         throw new IOException("cannot do this");
     }

--- a/src/main/java/org/apache/commons/mail/util/AttachmentDataSource.java
+++ b/src/main/java/org/apache/commons/mail/util/AttachmentDataSource.java
@@ -80,16 +80,16 @@ public class AttachmentDataSource implements DataSource
      */
     public OutputStream getOutputStream() throws IOException
     {
-        throw new IOException("cannot do this");
+        throw new UnsupportedOperationException("cannot do this");
     }
 
-    /** Get the content type. */
+    /** Gets the content type. */
     public String getContentType()
     {
         return this.type;
     }
 
-    /** Get the name. */
+    /** Gets the name. */
     public String getName()
     {
         return this.name;

--- a/src/main/java/org/apache/commons/mail/util/AttachmentDataSource.java
+++ b/src/main/java/org/apache/commons/mail/util/AttachmentDataSource.java
@@ -40,7 +40,7 @@ public class AttachmentDataSource implements DataSource
      * @param is   the InputStream
      * @param type the MIME type
      */
-    public AttachmentDataSource(final nputStream is, final String type)
+    public AttachmentDataSource(final InputStream is, final String type)
     {
         this.is = is;
         this.type = type;

--- a/src/main/java/org/apache/commons/mail/util/AttachmentDataSource.java
+++ b/src/main/java/org/apache/commons/mail/util/AttachmentDataSource.java
@@ -27,7 +27,8 @@ import java.io.OutputStream;
  *
  * @since 1.5
  */
-public class AttachmentDataSource implements DataSource {
+public class AttachmentDataSource implements DataSource
+{
     private final InputStream is;
     private final String type;
     private String name = "";
@@ -39,7 +40,8 @@ public class AttachmentDataSource implements DataSource {
      * @param is   the InputStream
      * @param type the MIME type
      */
-    public AttachmentDataSource(InputStream is, String type) {
+    public AttachmentDataSource(InputStream is, String type)
+    {
         this.is = is;
         this.type = type;
     }
@@ -53,7 +55,8 @@ public class AttachmentDataSource implements DataSource {
      * @param type
      * @param name
      */
-    public AttachmentDataSource(InputStream is, String type, String name) {
+    public AttachmentDataSource(InputStream is, String type, String name)
+    {
         this.is = is;
         this.type = type;
         this.name = name;
@@ -63,7 +66,8 @@ public class AttachmentDataSource implements DataSource {
      * Return an InputStream.
      * @return the InputStream
      */
-    public InputStream getInputStream() {
+    public InputStream getInputStream()
+    {
         return is;
     }
 
@@ -74,22 +78,26 @@ public class AttachmentDataSource implements DataSource {
      *
      * @throws IOException
      */
-    public OutputStream getOutputStream() throws IOException {
+    public OutputStream getOutputStream() throws IOException
+    {
         throw new IOException("cannot do this");
     }
 
     /** Get the content type. */
-    public String getContentType() {
+    public String getContentType()
+    {
         return this.type;
     }
 
     /** Get the name. */
-    public String getName() {
+    public String getName()
+    {
         return this.name;
     }
 
     /** Sets the name for this DataSource. */
-    public void setName(String name) {
+    public void setName(String name)
+    {
         this.name = name;
     }
 

--- a/src/main/java/org/apache/commons/mail/util/AttachmentDataSource.java
+++ b/src/main/java/org/apache/commons/mail/util/AttachmentDataSource.java
@@ -40,7 +40,7 @@ public class AttachmentDataSource implements DataSource
      * @param is   the InputStream
      * @param type the MIME type
      */
-    public AttachmentDataSource(InputStream is, String type)
+    public AttachmentDataSource(final nputStream is, final String type)
     {
         this.is = is;
         this.type = type;
@@ -55,7 +55,7 @@ public class AttachmentDataSource implements DataSource
      * @param type
      * @param name
      */
-    public AttachmentDataSource(InputStream is, String type, String name)
+    public AttachmentDataSource(final InputStream is, final String type, final String name)
     {
         this.is = is;
         this.type = type;

--- a/src/main/java/org/apache/commons/mail/util/AttachmentDataSource.java
+++ b/src/main/java/org/apache/commons/mail/util/AttachmentDataSource.java
@@ -25,7 +25,7 @@ import java.io.OutputStream;
  * A DataSource create with InputStream.
  * It is possible to set a name and type.
  *
- * @since 1.5
+ * @since 1.6.0
  */
 public class AttachmentDataSource implements DataSource
 {

--- a/src/main/java/org/apache/commons/mail/util/AttachmentDataSource.java
+++ b/src/main/java/org/apache/commons/mail/util/AttachmentDataSource.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.mail.util;
+
+import javax.activation.DataSource;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+/**
+ * A DataSource create with InputStream.
+ * It is possible to set a name and type.
+ *
+ * @since 1.5
+ */
+public class AttachmentDataSource implements DataSource {
+    private final InputStream is;
+    private final String type;
+    private String name = "";
+
+    public AttachmentDataSource(InputStream is, String type) {
+        this.is = is;
+        this.type = type;
+    }
+
+    public AttachmentDataSource(InputStream is, String type, String name) {
+        this.is = is;
+        this.type = type;
+        this.name = name;
+    }
+
+    public InputStream getInputStream() {
+        return is;
+    }
+
+    public OutputStream getOutputStream() throws IOException {
+        throw new IOException("cannot do this");
+    }
+
+    /** Get the content type. */
+    public String getContentType() {
+        return this.type;
+    }
+
+    /** Get the name. */
+    public String getName() {
+        return this.name;
+    }
+
+    /** Sets the name for this DataSource. */
+    public void setName(String name) {
+        this.name = name;
+    }
+
+}

--- a/src/main/java/org/apache/commons/mail/util/AttachmentDataSource.java
+++ b/src/main/java/org/apache/commons/mail/util/AttachmentDataSource.java
@@ -80,7 +80,7 @@ public class AttachmentDataSource implements DataSource
      */
     public OutputStream getOutputStream() throws IOException
     {
-        throw new UnsupportedOperationException("cannot do this");
+        throw new UnsupportedOperationException("getOutputStream()");
     }
 
     /** Gets the content type. */

--- a/src/main/java/org/apache/commons/mail/util/MimeMessageParser.java
+++ b/src/main/java/org/apache/commons/mail/util/MimeMessageParser.java
@@ -16,11 +16,7 @@
  */
 package org.apache.commons.mail.util;
 
-import java.io.BufferedInputStream;
-import java.io.BufferedOutputStream;
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -43,7 +39,6 @@ import javax.mail.internet.MimeMessage;
 import javax.mail.internet.MimePart;
 import javax.mail.internet.MimeUtility;
 import javax.mail.internet.ParseException;
-import javax.mail.util.ByteArrayDataSource;
 
 /**
  * Parses a MimeMessage and stores the individual parts such a plain text,
@@ -270,15 +265,8 @@ public class MimeMessageParser
         final DataHandler dataHandler = part.getDataHandler();
         final DataSource dataSource = dataHandler.getDataSource();
         final String contentType = getBaseMimeType(dataSource.getContentType());
-        byte[] content;
-        try (InputStream inputStream = dataSource.getInputStream()) 
-        {
-            content = this.getContent(inputStream);
-        }
-        final ByteArrayDataSource result = new ByteArrayDataSource(content, contentType);
         final String dataSourceName = getDataSourceName(part, dataSource);
-        result.setName(dataSourceName);
-        return result;
+        return new AttachmentDataSource(dataSource.getInputStream(), contentType, dataSourceName);
     }
 
     /** @return Returns the mimeMessage. */
@@ -408,29 +396,6 @@ public class MimeMessageParser
         }
 
         return result;
-    }
-
-    /**
-     * Read the content of the input stream.
-     *
-     * @param is the input stream to process
-     * @return the content of the input stream
-     * @throws IOException reading the input stream failed
-     */
-    private byte[] getContent(final InputStream is)
-        throws IOException
-    {
-        final ByteArrayOutputStream os = new ByteArrayOutputStream();
-        final BufferedInputStream isReader = new BufferedInputStream(is);
-        try (BufferedOutputStream osWriter = new BufferedOutputStream(os)) {
-            int ch;
-            while ((ch = isReader.read()) != -1)
-            {
-                osWriter.write(ch);
-            }
-            osWriter.flush();
-            return os.toByteArray();
-        }
     }
 
     /**

--- a/src/test/java/org/apache/commons/mail/util/AttachmentDataSourceTest.java
+++ b/src/test/java/org/apache/commons/mail/util/AttachmentDataSourceTest.java
@@ -27,7 +27,8 @@ import static org.junit.Assert.*;
 public class AttachmentDataSourceTest
 {
     @Test
-    public void testGetInputStream() throws IOException {
+    public void testGetInputStream() throws IOException
+    {
         byte[] testData = "Test data for InputStream".getBytes();
         InputStream testInputStream = new ByteArrayInputStream(testData);
 
@@ -42,26 +43,30 @@ public class AttachmentDataSourceTest
     }
 
     @Test
-    public void testGetContentType() {
+    public void testGetContentType()
+    {
         AttachmentDataSource dataSource = new AttachmentDataSource(null, "text/plain");
         assertEquals("text/plain", dataSource.getContentType());
     }
 
     @Test
-    public void testGetName() {
+    public void testGetName()
+    {
         AttachmentDataSource dataSource = new AttachmentDataSource(null, "application/pdf", "document.pdf");
         assertEquals("document.pdf", dataSource.getName());
     }
 
     @Test
-    public void testSetName() {
+    public void testSetName()
+    {
         AttachmentDataSource dataSource = new AttachmentDataSource(null, "image/jpeg");
         dataSource.setName("image.jpg");
         assertEquals("image.jpg", dataSource.getName());
     }
 
     @Test
-    public void testGetOutputStream() {
+    public void testGetOutputStream()
+    {
         AttachmentDataSource dataSource = new AttachmentDataSource(null, "text/html");
         assertThrows(IOException.class, dataSource::getOutputStream);
     }

--- a/src/test/java/org/apache/commons/mail/util/AttachmentDataSourceTest.java
+++ b/src/test/java/org/apache/commons/mail/util/AttachmentDataSourceTest.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.mail.util;
+
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+import static org.junit.Assert.*;
+
+public class AttachmentDataSourceTest
+{
+    @Test
+    public void testGetInputStream() throws IOException {
+        byte[] testData = "Test data for InputStream".getBytes();
+        InputStream testInputStream = new ByteArrayInputStream(testData);
+
+        AttachmentDataSource dataSource = new AttachmentDataSource(testInputStream, "application/octet-stream");
+        InputStream inputStream = dataSource.getInputStream();
+
+        byte[] readData = new byte[testData.length];
+        int bytesRead = inputStream.read(readData);
+
+        assertEquals(testData.length, bytesRead);
+        assertArrayEquals(testData, readData);
+    }
+
+    @Test
+    public void testGetContentType() {
+        AttachmentDataSource dataSource = new AttachmentDataSource(null, "text/plain");
+        assertEquals("text/plain", dataSource.getContentType());
+    }
+
+    @Test
+    public void testGetName() {
+        AttachmentDataSource dataSource = new AttachmentDataSource(null, "application/pdf", "document.pdf");
+        assertEquals("document.pdf", dataSource.getName());
+    }
+
+    @Test
+    public void testSetName() {
+        AttachmentDataSource dataSource = new AttachmentDataSource(null, "image/jpeg");
+        dataSource.setName("image.jpg");
+        assertEquals("image.jpg", dataSource.getName());
+    }
+
+    @Test
+    public void testGetOutputStream() {
+        AttachmentDataSource dataSource = new AttachmentDataSource(null, "text/html");
+        assertThrows(IOException.class, dataSource::getOutputStream);
+    }
+
+}

--- a/src/test/java/org/apache/commons/mail/util/AttachmentDataSourceTest.java
+++ b/src/test/java/org/apache/commons/mail/util/AttachmentDataSourceTest.java
@@ -29,14 +29,14 @@ public class AttachmentDataSourceTest
     @Test
     public void testGetInputStream() throws IOException
     {
-        byte[] testData = "Test data for InputStream".getBytes();
-        InputStream testInputStream = new ByteArrayInputStream(testData);
+        final byte[] testData = "Test data for InputStream".getBytes();
+        final InputStream testInputStream = new ByteArrayInputStream(testData);
 
-        AttachmentDataSource dataSource = new AttachmentDataSource(testInputStream, "application/octet-stream");
-        InputStream inputStream = dataSource.getInputStream();
+        final AttachmentDataSource dataSource = new AttachmentDataSource(testInputStream, "application/octet-stream");
+        final InputStream inputStream = dataSource.getInputStream();
 
-        byte[] readData = new byte[testData.length];
-        int bytesRead = inputStream.read(readData);
+        final byte[] readData = new byte[testData.length];
+        final int bytesRead = inputStream.read(readData);
 
         assertEquals(testData.length, bytesRead);
         assertArrayEquals(testData, readData);
@@ -45,21 +45,21 @@ public class AttachmentDataSourceTest
     @Test
     public void testGetContentType()
     {
-        AttachmentDataSource dataSource = new AttachmentDataSource(null, "text/plain");
+        final AttachmentDataSource dataSource = new AttachmentDataSource(null, "text/plain");
         assertEquals("text/plain", dataSource.getContentType());
     }
 
     @Test
     public void testGetName()
     {
-        AttachmentDataSource dataSource = new AttachmentDataSource(null, "application/pdf", "document.pdf");
+        final AttachmentDataSource dataSource = new AttachmentDataSource(null, "application/pdf", "document.pdf");
         assertEquals("document.pdf", dataSource.getName());
     }
 
     @Test
     public void testSetName()
     {
-        AttachmentDataSource dataSource = new AttachmentDataSource(null, "image/jpeg");
+        final AttachmentDataSource dataSource = new AttachmentDataSource(null, "image/jpeg");
         dataSource.setName("image.jpg");
         assertEquals("image.jpg", dataSource.getName());
     }
@@ -67,7 +67,7 @@ public class AttachmentDataSourceTest
     @Test
     public void testGetOutputStream()
     {
-        AttachmentDataSource dataSource = new AttachmentDataSource(null, "text/html");
+        final AttachmentDataSource dataSource = new AttachmentDataSource(null, "text/html");
         assertThrows(UnsupportedOperationException.class, dataSource::getOutputStream);
     }
 

--- a/src/test/java/org/apache/commons/mail/util/AttachmentDataSourceTest.java
+++ b/src/test/java/org/apache/commons/mail/util/AttachmentDataSourceTest.java
@@ -68,7 +68,7 @@ public class AttachmentDataSourceTest
     public void testGetOutputStream()
     {
         AttachmentDataSource dataSource = new AttachmentDataSource(null, "text/html");
-        assertThrows(IOException.class, dataSource::getOutputStream);
+        assertThrows(UnsupportedOperationException.class, dataSource::getOutputStream);
     }
 
 }


### PR DESCRIPTION
### Issue

Hello,

OOM occurred in the mail service developed using Apache-commons-email.

I debugged and found that the mail lookup function was wasting memory!

### Problem

Below is a test for reproducing the problem.

```java
@Test
void memoryTest() throws Exception {
    InputStream is = new SharedFileInputStream("/test/oom.eml");
    Session session = Session.getInstance(System.getProperties());
    MimeMessage mimeMessage = new MimeMessage(session, is);
    MimeMessageParser parser = new MimeMessageParser(mimeMessage).parse();
}
```

Below is the memory usage.

![img](https://github.com/apache/commons-email/assets/63458653/721ddcb7-b30b-4688-afc4-6f773c85b6a8)

I expected to write attachments to the buffer of the output stream when absolutely necessary.

However, it is becoming a problem by putting all bytes[] in memory.

![img_3](https://github.com/apache/commons-email/assets/63458653/67c7f208-fc4a-4954-823a-3a6904d21dd7)

![img_1](https://github.com/apache/commons-email/assets/63458653/8b144f5a-2b15-4c9a-a070-4d179e0b1d09)

### Sugest

So i modified these processes to use AttachmentDataSource.

Attachment DataSource uses InputStream from original DataSource to ensure memory is not wasted.

As a result, i can get a big effect in memory usage.

![img_2](https://github.com/apache/commons-email/assets/63458653/9adb56e3-8a57-49ad-aec7-1324860b0f30)

> I worked hard to fix it. Feel free to let me know if you have any advice or lack!

If you need the tested eml file, I will send it to you by email.

Thanks very much. 🙇
