### PR TITLE
Handle IllegalArgumentException thrown for invalid email address

### DIFF
--- a/commons-email2-jakarta/src/main/java/org/apache/commons/mail2/jakarta/Email.java
+++ b/commons-email2-jakarta/src/main/java/org/apache/commons/mail2/jakarta/Email.java
@@ -630,7 +630,12 @@ public abstract class Email {
      */
     private InternetAddress createInternetAddress(final String email, final String name, final String charsetName) throws EmailException {
         try {
-            final InternetAddress address = new InternetAddress(new IDNEmailAddressConverter().toASCII(email));
+            final InternetAddress address;
+            try {
+                address = new InternetAddress(new IDNEmailAddressConverter().toASCII(email));
+            } catch (final IllegalArgumentException e) {
+                throw new EmailException(e);
+            }
             // check name input
             if (EmailUtils.isNotEmpty(name)) {
                 // check charset input.
@@ -647,7 +652,7 @@ public abstract class Email {
             // it will throw AddressException.
             address.validate();
             return address;
-        } catch (final AddressException | UnsupportedEncodingException | IllegalArgumentException e) {
+        } catch (final AddressException | UnsupportedEncodingException e) {
             throw new EmailException(e);
         }
     }

--- a/commons-email2-jakarta/src/main/java/org/apache/commons/mail2/jakarta/Email.java
+++ b/commons-email2-jakarta/src/main/java/org/apache/commons/mail2/jakarta/Email.java
@@ -647,7 +647,7 @@ public abstract class Email {
             // it will throw AddressException.
             address.validate();
             return address;
-        } catch (final AddressException | UnsupportedEncodingException e) {
+        } catch (final AddressException | UnsupportedEncodingException | IllegalArgumentException e) {
             throw new EmailException(e);
         }
     }

--- a/commons-email2-jakarta/src/main/java/org/apache/commons/mail2/jakarta/util/IDNEmailAddressConverter.java
+++ b/commons-email2-jakarta/src/main/java/org/apache/commons/mail2/jakarta/util/IDNEmailAddressConverter.java
@@ -66,6 +66,7 @@ public class IDNEmailAddressConverter {
      *
      * @param email email address.
      * @return The ASCII representation
+     * @throws IllegalArgumentException if the domain doesn't conform to RFC 3490 specification
      */
     public String toASCII(final String email) {
         return toString(email, IDN::toASCII);

--- a/commons-email2-jakarta/src/test/java/org/apache/commons/mail2/jakarta/InvalidAddressTest.java
+++ b/commons-email2-jakarta/src/test/java/org/apache/commons/mail2/jakarta/InvalidAddressTest.java
@@ -55,6 +55,7 @@ public class InvalidAddressTest extends AbstractEmailTest {
             "local.name@domain,com",
             "local.name@domain;com",
             "local.name@domain:com",
+            "local.name@domain..com",
             // "local.name@domain[com",
             "local.name@domain]com",
             "local.name@domain\\com",

--- a/commons-email2-jakarta/src/test/java/org/apache/commons/mail2/jakarta/InvalidInternetAddressTest.java
+++ b/commons-email2-jakarta/src/test/java/org/apache/commons/mail2/jakarta/InvalidInternetAddressTest.java
@@ -59,6 +59,7 @@ public class InvalidInternetAddressTest extends AbstractEmailTest {
             "local.name@domain,com",
             "local.name@domain;com",
             "local.name@domain:com",
+            "local.name@domain..com",
             // "local.name@domain[com", -- works for javamail-1.5.5
             "local.name@domain]com",
             "local.name@domain\\com",

--- a/commons-email2-javax/src/main/java/org/apache/commons/mail2/javax/Email.java
+++ b/commons-email2-javax/src/main/java/org/apache/commons/mail2/javax/Email.java
@@ -629,7 +629,12 @@ public abstract class Email {
      */
     private InternetAddress createInternetAddress(final String email, final String name, final String charsetName) throws EmailException {
         try {
-            final InternetAddress address = new InternetAddress(new IDNEmailAddressConverter().toASCII(email));
+            final InternetAddress address;
+            try {
+                address = new InternetAddress(new IDNEmailAddressConverter().toASCII(email));
+            } catch (final IllegalArgumentException e) {
+                throw new EmailException(e);
+            }
             // check name input
             if (EmailUtils.isNotEmpty(name)) {
                 // check charset input.
@@ -646,7 +651,7 @@ public abstract class Email {
             // it will throw AddressException.
             address.validate();
             return address;
-        } catch (final AddressException | UnsupportedEncodingException | IllegalArgumentException e) {
+        } catch (final AddressException | UnsupportedEncodingException e) {
             throw new EmailException(e);
         }
     }

--- a/commons-email2-javax/src/main/java/org/apache/commons/mail2/javax/Email.java
+++ b/commons-email2-javax/src/main/java/org/apache/commons/mail2/javax/Email.java
@@ -646,7 +646,7 @@ public abstract class Email {
             // it will throw AddressException.
             address.validate();
             return address;
-        } catch (final AddressException | UnsupportedEncodingException e) {
+        } catch (final AddressException | UnsupportedEncodingException | IllegalArgumentException e) {
             throw new EmailException(e);
         }
     }

--- a/commons-email2-javax/src/main/java/org/apache/commons/mail2/javax/util/IDNEmailAddressConverter.java
+++ b/commons-email2-javax/src/main/java/org/apache/commons/mail2/javax/util/IDNEmailAddressConverter.java
@@ -66,6 +66,7 @@ public class IDNEmailAddressConverter {
      *
      * @param email email address.
      * @return The ASCII representation
+     * @throws IllegalArgumentException if the domain doesn't conform to RFC 3490 specification
      */
     public String toASCII(final String email) {
         return toString(email, IDN::toASCII);

--- a/commons-email2-javax/src/test/java/org/apache/commons/mail2/javax/InvalidAddressTest.java
+++ b/commons-email2-javax/src/test/java/org/apache/commons/mail2/javax/InvalidAddressTest.java
@@ -55,6 +55,7 @@ public class InvalidAddressTest extends AbstractEmailTest {
             "local.name@domain,com",
             "local.name@domain;com",
             "local.name@domain:com",
+            "local.name@domain..com",
             // "local.name@domain[com",
             "local.name@domain]com",
             "local.name@domain\\com",

--- a/commons-email2-javax/src/test/java/org/apache/commons/mail2/javax/InvalidInternetAddressTest.java
+++ b/commons-email2-javax/src/test/java/org/apache/commons/mail2/javax/InvalidInternetAddressTest.java
@@ -59,6 +59,7 @@ public class InvalidInternetAddressTest extends AbstractEmailTest {
             "local.name@domain,com",
             "local.name@domain;com",
             "local.name@domain:com",
+            "local.name@domain..com",
             // "local.name@domain[com", -- works for javamail-1.5.5
             "local.name@domain]com",
             "local.name@domain\\com",


### PR DESCRIPTION
`java.net.IDN.toASCII` throws an `IllegalArgumentException` for a domain like `domain..com`. This PR translates it to an `EmailException`.