### PR TITLE
EMAIL-212 MIME closing boundary delimiter incorrectly accepted when followed by extra characters

### DIFF
--- a/commons-email2-javax/src/test/resources/eml/multipart-ending-boundary.eml
+++ b/commons-email2-javax/src/test/resources/eml/multipart-ending-boundary.eml
@@ -1,0 +1,22 @@
+Return-Path: <test_from@apache.org>
+Message-ID: <blabla@gmail.com>
+Date: Fri, 02 Aug 2013 20:53:33 +0200
+From: test_from@apache.org
+MIME-Version: 1.0
+To: test_to@apache.org
+Subject: test
+Content-Type: multipart/mixed;
+ boundary="------------010700020404090103050203"
+
+This is a multi-part message in MIME format.
+--------------010700020404090103050203
+Content-Type: text/plain; charset=UTF-8;
+ name="test.txt"
+Content-Transfer-Encoding: 7bit
+Content-Disposition: attachment;
+
+test
+
+--------------010700020404090103050203--MORE
+
+--------------010700020404090103050203--


### PR DESCRIPTION
Submit a failing testcase for the issue reported at Jira [EMAIL-212](https://issues.apache.org/jira/browse/EMAIL-212)

According to RFC 2046 §5.1.1, a boundary delimiter line is defined as:
> a line consisting entirely of two hyphen characters ("--"), followed by the boundary parameter value from the Content-Type header, optionally followed by whitespace, and terminated by CRLF.

Tested on a few peer implementations and found that they all obtained the body content as shown in the unit test.